### PR TITLE
gstavrinos-multivac: new kartland record!

### DIFF
--- a/kartland.md
+++ b/kartland.md
@@ -1,0 +1,3 @@
+| user | raw time | readable time |
+| - | - | - |
+| gstavrinos-multivac | 588.2 | 09:48.2000 |


### PR DESCRIPTION
At `2022-10-10_13-35-28` in `git://github.com/gstavrinos-multivac/test_kart_navigation.git`, commit: `a4b2ed90315aaf6c2bfc1db9a3d5bb40be676f6b`, triggered by `ROS2 Kart Racing Competition Entry` with a `push` event from the `__gstavrinos_ros2_kart_racing_action` action.