### PR TITLE
gstavrinos-hal9000: new kartland record!

### DIFF
--- a/kartland.md
+++ b/kartland.md
@@ -1,3 +1,4 @@
 | user | raw time | readable time |
 | - | - | - |
 | gstavrinos-multivac | 583.6 | 09:43.6000 |
+| gstavrinos-hal9000 | 587.22 | 09:47.2200 |


### PR DESCRIPTION
At `2022-10-10_16-44-02` in `git://github.com/gstavrinos-hal9000/test_kart_navigation2.git`, commit: `48e275a7715a07365cd778080d47a06d2ce1ab88`, triggered by `ROS2 Kart Racing Competition Entry` with a `push` event from the `__gstavrinos_ros2_kart_racing_action` action.