### PR TITLE
gstavrinos-multivac: new speedpark record!

### DIFF
--- a/speedpark.md
+++ b/speedpark.md
@@ -1,0 +1,3 @@
+| user | raw time | readable time |
+| - | - | - |
+| gstavrinos-multivac | 1281.3400000000001 | 21:21.3400 |


### PR DESCRIPTION
At `2022-10-13_09-59-49` in `git://github.com/gstavrinos-multivac/test_kart_navigation.git`, commit: `8aa16d167a4d6855a92b1b0588b8302263af5c43`, triggered by `ROS2 Kart Racing Competition Entry` with a `push` event from the `__gstavrinos_ros2_kart_racing_action` action.